### PR TITLE
add descriptions for SideMenu tests

### DIFF
--- a/tests/UI/SideMenu.test.tsx
+++ b/tests/UI/SideMenu.test.tsx
@@ -16,4 +16,64 @@ describe("SideMenu", () => {
       expect(screen.getByText("recent unreads")).toBeInTheDocument();
     });
   });
+
+  test("Correctly dismisses board notifications from dropdown menu", async () => {
+    render(
+      <Client router={BASE_ROUTER}>
+        <SideMenu />
+      </Client>
+    );
+  
+    //TODO: fill this
+  });
+  
+  test("Board filter correctly filters boards", async () => {
+    render(
+      <Client router={BASE_ROUTER}>
+        <SideMenu />
+      </Client>
+    );
+  
+    //TODO: fill this
+  });
+  
+  test("Board filter correctly unfilters boards on entry deletion", async () => {
+    render(
+      <Client router={BASE_ROUTER}>
+        <SideMenu />
+      </Client>
+    );
+  
+    //TODO: fill this
+  });
+  
+  test("Renders empty section if no boards match filter search", async () => {
+    render(
+      <Client router={BASE_ROUTER}>
+        <SideMenu />
+      </Client>
+    );
+  
+    //TODO: fill this
+  });
+  
+  test("Pinning board adds it to Pinned menu", async () => {
+    render(
+      <Client router={BASE_ROUTER}>
+        <SideMenu />
+      </Client>
+    );
+  
+    //TODO: fill this
+  });
+  
+  test("Unpinning board removes it from Pinned menu", async () => {
+    render(
+      <Client router={BASE_ROUTER}>
+        <SideMenu />
+      </Client>
+    );
+  
+    //TODO: fill this
+  });
 });


### PR DESCRIPTION
Added test descriptions for Side Menu tests that should be here instead of in bobaboard-ui