### PR TITLE
Random cleanups + "Filterable Context"

### DIFF
--- a/components/options/useTagsOptions.ts
+++ b/components/options/useTagsOptions.ts
@@ -4,6 +4,7 @@ import type { Post, TagsType } from "@bobaboard/ui-components";
 import React from "react";
 import { TagType } from "@bobaboard/ui-components";
 import { faFilter } from "@fortawesome/free-solid-svg-icons";
+import { useFilterableContext } from "contexts/FilterableContext";
 import { useThreadViewContext } from "contexts/ThreadViewContext";
 
 export enum TagsOptions {
@@ -19,10 +20,10 @@ type PostProps = GetPropsFromForwardedRef<typeof Post>;
  */
 const getTagFilterOption = ({
   tag,
-  setActiveFilter,
+  setActiveCategories,
 }: {
   tag: TagsType;
-  setActiveFilter: (tag: string) => void;
+  setActiveCategories: (tags: string[]) => void;
 }) => {
   if (!tag || tag.type != TagType.CATEGORY) {
     return null;
@@ -33,7 +34,7 @@ const getTagFilterOption = ({
     name: "Filter",
     link: {
       onClick: () => {
-        setActiveFilter(tag.name);
+        setActiveCategories([tag.name]);
       },
     },
   };
@@ -45,16 +46,16 @@ const getTagFilterOption = ({
  * - null, if the option is non available for that tag
  */
 const useGetDropdownItemFromOption = () => {
-  const { setActiveFilter } = useThreadViewContext();
+  const { setActiveCategories } = useFilterableContext();
 
   return React.useCallback(
     ({ tag, option }: { tag: TagsType; option: TagsOptions }) => {
       switch (option) {
         case TagsOptions.FILTER_BY_CATEGORY:
-          return getTagFilterOption({ tag, setActiveFilter });
+          return getTagFilterOption({ tag, setActiveCategories });
       }
     },
-    [setActiveFilter]
+    [setActiveCategories]
   );
 };
 

--- a/components/thread/ThreadSidebar.tsx
+++ b/components/thread/ThreadSidebar.tsx
@@ -5,16 +5,14 @@ import {
   TagType,
   TagsFilterSection,
 } from "@bobaboard/ui-components";
-import {
-  THREAD_VIEW_MODE,
-  useThreadViewContext,
-} from "contexts/ThreadViewContext";
 
 import { DisplayManager } from "components/hooks/useDisplayMananger";
 import React from "react";
+import { THREAD_VIEW_MODE } from "contexts/ThreadViewContext";
 import { UNCATEGORIZED_LABEL } from "utils/thread-utils";
 import classnames from "classnames";
 import { formatDistanceToNow } from "date-fns";
+import { useFilterableContext } from "contexts/FilterableContext";
 import { useForceHideIdentity } from "components/hooks/useForceHideIdentity";
 import { useThreadContext } from "components/thread/ThreadContext";
 
@@ -29,11 +27,11 @@ const ThreadSidebar: React.FC<ThreadSidebarProps> = (props) => {
   const { forceHideIdentity } = useForceHideIdentity();
   const { threadRoot, categories, contentNotices } = useThreadContext();
   const {
-    setActiveFilter,
-    activeFilters,
-    setExcludedNotices,
-    excludedNotices,
-  } = useThreadViewContext();
+    activeCategories,
+    setActiveCategories,
+    filteredNotices,
+    setFilteredNotices,
+  } = useFilterableContext();
   if (!threadRoot) {
     return null;
   }
@@ -96,24 +94,24 @@ const ThreadSidebar: React.FC<ThreadSidebarProps> = (props) => {
               tags={contentNotices.map((notice) => ({
                 name: notice,
                 state:
-                  excludedNotices == null || !excludedNotices.includes(notice)
+                  !filteredNotices.length || filteredNotices.includes(notice)
                     ? TagsFilterSection.FilteredTagsState.ACTIVE
                     : TagsFilterSection.FilteredTagsState.DISABLED,
               }))}
               onTagsStateChangeRequest={(notice) => {
-                if (excludedNotices?.includes(notice)) {
-                  const newNotices = excludedNotices.filter(
+                if (filteredNotices?.includes(notice)) {
+                  const newNotices = filteredNotices.filter(
                     (existingNotice) => existingNotice != notice
                   );
-                  setExcludedNotices(newNotices.length > 0 ? newNotices : null);
+                  setFilteredNotices(newNotices);
                   return;
                 }
-                setExcludedNotices(
-                  excludedNotices ? [...excludedNotices, notice] : [notice]
+                setFilteredNotices(
+                  filteredNotices ? [...filteredNotices, notice] : [notice]
                 );
               }}
               onClearFilterRequests={() => {
-                setExcludedNotices(null);
+                setFilteredNotices([]);
               }}
               type={TagType.CONTENT_WARNING}
             />
@@ -127,24 +125,25 @@ const ThreadSidebar: React.FC<ThreadSidebarProps> = (props) => {
               tags={categories.map((category) => ({
                 name: category,
                 state:
-                  activeFilters == null || activeFilters.includes(category)
+                  !activeCategories.length ||
+                  activeCategories.includes(category)
                     ? TagsFilterSection.FilteredTagsState.ACTIVE
                     : TagsFilterSection.FilteredTagsState.DISABLED,
               }))}
               onTagsStateChangeRequest={(name) => {
-                setActiveFilter(name);
+                setActiveCategories([name]);
               }}
               onClearFilterRequests={() => {
-                setActiveFilter(null);
+                setActiveCategories([]);
               }}
               uncategorized={
-                activeFilters == null ||
-                activeFilters.includes(UNCATEGORIZED_LABEL)
+                !activeCategories.length ||
+                activeCategories.includes(UNCATEGORIZED_LABEL)
                   ? TagsFilterSection.FilteredTagsState.ACTIVE
                   : TagsFilterSection.FilteredTagsState.DISABLED
               }
               onUncategorizedStateChangeRequest={() => {
-                setActiveFilter(UNCATEGORIZED_LABEL);
+                setActiveCategories([UNCATEGORIZED_LABEL]);
               }}
               type={TagType.CATEGORY}
             />

--- a/contexts/FilterableContext.tsx
+++ b/contexts/FilterableContext.tsx
@@ -16,8 +16,8 @@ const FilterableContext = React.createContext<
   | {
       activeCategories: string[];
       setActiveCategories: (categories: string[]) => void;
-      //   filteredNotices: string[];
-      //   setFilteredNotices: (filters: string[]) => void;
+      filteredNotices: string[];
+      setFilteredNotices: (filters: string[]) => void;
     }
   | undefined
 >(undefined);
@@ -55,14 +55,26 @@ const useSetActiveCategories = () => {
 const FilterableContextProvider: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
-  const [{ filter }, setQuery] = useQueryParams(FilterParams);
+  const [{ filter, filteredNotices }, setQuery] = useQueryParams(FilterParams);
   const setActiveCategories = React.useCallback(
     (activeCategories: string[]) => {
       setQuery(
         {
           filter: activeCategories.length == 1 ? activeCategories : undefined,
         },
-        "replace"
+        "push"
+      );
+    },
+    [setQuery]
+  );
+  const setFilteredNotices = React.useCallback(
+    (filteredNotices: string[]) => {
+      setQuery(
+        {
+          filteredNotices:
+            filteredNotices.length == 1 ? filteredNotices : undefined,
+        },
+        "push"
       );
     },
     [setQuery]
@@ -74,8 +86,10 @@ const FilterableContextProvider: React.FC<{
         () => ({
           activeCategories: (filter ?? []).filter(isNotNull),
           setActiveCategories,
+          filteredNotices: (filteredNotices ?? []).filter(isNotNull),
+          setFilteredNotices: setFilteredNotices,
         }),
-        [filter, setActiveCategories]
+        [filter, setActiveCategories, filteredNotices, setFilteredNotices]
       )}
     >
       {children}

--- a/contexts/FilterableContext.tsx
+++ b/contexts/FilterableContext.tsx
@@ -1,0 +1,92 @@
+import { ArrayParam } from "use-query-params";
+import React from "react";
+import debug from "debug";
+import { isNotNull } from "utils/typescript-utils";
+import { useQueryParams } from "use-query-params";
+
+//const log = debug("bobafrontend:contexts:RealmContext-log");
+const info = debug("bobafrontend:contexts:FilterableContext-info");
+
+export const FilterParams = {
+  filter: ArrayParam,
+  filteredNotices: ArrayParam,
+};
+
+const FilterableContext = React.createContext<
+  | {
+      activeCategories: string[];
+      setActiveCategories: (categories: string[]) => void;
+      //   filteredNotices: string[];
+      //   setFilteredNotices: (filters: string[]) => void;
+    }
+  | undefined
+>(undefined);
+
+const useFilterableContext = () => {
+  const context = React.useContext(FilterableContext);
+  if (context === undefined) {
+    throw new Error(
+      "useFilterableContext must be used within a FilterableContextProvider"
+    );
+  }
+  return context;
+};
+
+const useActiveCategories = () => {
+  const context = React.useContext(FilterableContext);
+  if (context === undefined) {
+    throw new Error(
+      "useActiveCategories must be used within a FilterableContextProvider"
+    );
+  }
+  return context.activeCategories;
+};
+
+const useSetActiveCategories = () => {
+  const context = React.useContext(FilterableContext);
+  if (context === undefined) {
+    throw new Error(
+      "useSetActiveCategories must be used within a FilterableContextProvider"
+    );
+  }
+  return context.setActiveCategories;
+};
+
+const FilterableContextProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [{ filter }, setQuery] = useQueryParams(FilterParams);
+  const setActiveCategories = React.useCallback(
+    (activeCategories: string[]) => {
+      setQuery(
+        {
+          filter: activeCategories.length == 1 ? activeCategories : undefined,
+        },
+        "replace"
+      );
+    },
+    [setQuery]
+  );
+
+  return (
+    <FilterableContext.Provider
+      value={React.useMemo(
+        () => ({
+          activeCategories: (filter ?? []).filter(isNotNull),
+          setActiveCategories,
+        }),
+        [filter, setActiveCategories]
+      )}
+    >
+      {children}
+    </FilterableContext.Provider>
+  );
+};
+const MemoizedProvider = React.memo(FilterableContextProvider);
+
+export {
+  MemoizedProvider as FilterableContextProvider,
+  useFilterableContext,
+  useActiveCategories,
+  useSetActiveCategories,
+};

--- a/pages/[boardId]/thread/[...threadId].tsx
+++ b/pages/[boardId]/thread/[...threadId].tsx
@@ -22,6 +22,7 @@ import {
 } from "contexts/RealmContext";
 import { useThreadEditors, withEditors } from "components/editors/withEditors";
 
+import { FilterableContextProvider } from "contexts/FilterableContext";
 import GalleryThreadView from "components/thread/GalleryThreadView";
 import Layout from "components/layout/Layout";
 import LoadingSpinner from "components/LoadingSpinner";
@@ -304,7 +305,9 @@ const ThreadPageWithContext: React.FC<{
       threadId={threadId}
     >
       <ThreadViewContextProvider>
-        <ThreadPage />
+        <FilterableContextProvider>
+          <ThreadPage />
+        </FilterableContextProvider>
       </ThreadViewContextProvider>
     </ThreadContextProvider>
   );

--- a/types/ThreadQueryParams.ts
+++ b/types/ThreadQueryParams.ts
@@ -44,11 +44,6 @@ export interface TimelineViewMode {
   timelineViewMode: TIMELINE_VIEW_SUB_MODE;
 }
 
-export interface ThreadFilters {
-  activeFilters: string[] | null;
-  excludedNotices: string[] | null;
-}
-
 export type ThreadViewMode =
   | ClassicThreadViewMode
   | GalleryViewMode


### PR DESCRIPTION
Filterable Context="mark sections of stuff (Boards/Threads) as filterable by category (see: React Contexts for idea)"

Missing: there's a bug in thread view (but not in board view) where back/forward stop working. The matrioska of ThreadViewContext and FilterableContext being nested into each other is the most likely culprit, and debugging that can get pretty gnarly*.

* By which I mean, this is free for the taking 
