### PR TITLE
Minimize Editors hack

### DIFF
--- a/components/editors/CommentEditorModal.tsx
+++ b/components/editors/CommentEditorModal.tsx
@@ -84,7 +84,7 @@ const CommentEditorModal: React.FC<CommentEditorModalProps> = (props) => {
         .editor {
           display: flex;
           justify-content: center;
-          padding: 15px;
+          padding: 0 15px 15px;
         }
       `}</style>
     </div>

--- a/components/editors/ContributionEditorModal.tsx
+++ b/components/editors/ContributionEditorModal.tsx
@@ -230,14 +230,12 @@ const ContributionEditorModal: React.FC<PostEditorModalProps> = (props) => {
           avatar: currentBoard!.avatarUrl,
         }}
         availableBoards={isNewThread(state) ? allBoards : undefined}
-        onMinimize={props.onMinimize}
-        minimizable={!!props.onMinimize}
       />
       <style jsx>{`
         .editor {
           display: flex;
           justify-content: center;
-          padding: 15px;
+          padding: 0 15px 15px;
         }
       `}</style>
     </div>
@@ -247,7 +245,6 @@ const ContributionEditorModal: React.FC<PostEditorModalProps> = (props) => {
 export interface PostEditorModalProps {
   onCancel: (empty: boolean) => void;
   onPostSaved: (post: PostType, boardId?: string) => void;
-  onMinimize?: () => void;
   loading?: boolean;
 }
 

--- a/components/editors/ContributionEditorModal.tsx
+++ b/components/editors/ContributionEditorModal.tsx
@@ -230,6 +230,8 @@ const ContributionEditorModal: React.FC<PostEditorModalProps> = (props) => {
           avatar: currentBoard!.avatarUrl,
         }}
         availableBoards={isNewThread(state) ? allBoards : undefined}
+        onMinimize={props.onMinimize}
+        minimizable={!!props.onMinimize}
       />
       <style jsx>{`
         .editor {
@@ -245,6 +247,7 @@ const ContributionEditorModal: React.FC<PostEditorModalProps> = (props) => {
 export interface PostEditorModalProps {
   onCancel: (empty: boolean) => void;
   onPostSaved: (post: PostType, boardId?: string) => void;
+  onMinimize?: () => void;
   loading?: boolean;
 }
 

--- a/components/editors/types.ts
+++ b/components/editors/types.ts
@@ -104,6 +104,16 @@ export const isNewThread = (state: EditorState): state is NewThreadState => {
   );
 };
 
+export const isReplyContribution = (
+  state: EditorState
+): state is NewContributionState => {
+  return (
+    state.isOpen &&
+    isContributionEditorState(state) &&
+    "newContribution" in state
+  );
+};
+
 export const isEditContribution = (
   state: EditorState
 ): state is EditContributionState => {

--- a/components/editors/withEditors.tsx
+++ b/components/editors/withEditors.tsx
@@ -75,11 +75,15 @@ const Editors = () => {
 
   return (
     <>
-      <Modal isOpen={true} isMinimized={isMinimized}>
+      <Modal
+        isOpen={true}
+        isMinimized={isMinimized}
+        onMinimize={onMinimize}
+        minimizable={!isNewThread(state)}
+      >
         {isContributionEditorState(state) && (
           <ContributionEditorModal
             loading={isRefetching}
-            onMinimize={onMinimize}
             onPostSaved={(post: PostType, postedBoardId: string) => {
               if (isEditContribution(state)) {
                 setPostTagsInCache(queryClient, {

--- a/components/editors/withEditors.tsx
+++ b/components/editors/withEditors.tsx
@@ -49,16 +49,37 @@ const Editors = () => {
   const refetchBoardActivity = useRefetchBoardActivity();
   const [isRefetching, setRefetching] = React.useState(false);
   const boards = useRealmBoards();
+  const [isMinimized, setMinimized] = React.useState(false);
+  const onMinimize = () => {
+    if (isMinimized) {
+      document.body.style.overflow = "hidden";
+      // TODO: this is bad and horrible (we should not use query selector)
+      const layoutNode = document.querySelector(".layout") as HTMLDivElement;
+      if (layoutNode) {
+        layoutNode.style.overflow = "hidden";
+      }
+    } else {
+      document.body.style.overflow = "";
+      // TODO: this is bad and horrible (we should not use query selector)
+      const layoutNode = document.querySelector(".layout") as HTMLDivElement;
+      if (layoutNode) {
+        layoutNode.style.overflow = "";
+      }
+    }
+    setMinimized(!isMinimized);
+  };
+
   if (!isLoggedIn || isAuthPending || !state.isOpen) {
     return null;
   }
 
   return (
     <>
-      <Modal isOpen={true}>
+      <Modal isOpen={true} isMinimized={isMinimized}>
         {isContributionEditorState(state) && (
           <ContributionEditorModal
             loading={isRefetching}
+            onMinimize={onMinimize}
             onPostSaved={(post: PostType, postedBoardId: string) => {
               if (isEditContribution(state)) {
                 setPostTagsInCache(queryClient, {

--- a/components/editors/withEditors.tsx
+++ b/components/editors/withEditors.tsx
@@ -30,9 +30,11 @@ const Editors = () => {
   const { isLoggedIn, isPending: isAuthPending } = useAuth();
   const { getLinkToBoard } = useCachedLinks();
   const queryClient = useQueryClient();
+  const [isMinimized, setMinimized] = React.useState(false);
   const dispatch = useEditorsDispatch();
   const onClose = React.useCallback(() => {
     dispatch({ type: EditorActions.CLOSE, payload: {} });
+    setMinimized(false);
   }, [dispatch]);
   const state = useEditorsState();
   usePreventPageChange(() => state.isOpen, onClose, [state.isOpen]);
@@ -49,7 +51,6 @@ const Editors = () => {
   const refetchBoardActivity = useRefetchBoardActivity();
   const [isRefetching, setRefetching] = React.useState(false);
   const boards = useRealmBoards();
-  const [isMinimized, setMinimized] = React.useState(false);
   const onMinimize = () => {
     if (isMinimized) {
       document.body.style.overflow = "hidden";

--- a/components/hooks/usePreventPageChange.ts
+++ b/components/hooks/usePreventPageChange.ts
@@ -5,11 +5,13 @@ import debug from "debug";
 
 // @ts-expect-error
 const info = debug("bobafrontend:hooks:preventPageChange-info");
+const log = debug("bobafrontend:hooks:preventPageChange-log");
+// log.enabled = true;
 
 const POP_STATE_CALLBACKS = [] as ((state: any) => boolean)[];
 export const usePreventPageChange = (
   shouldPrevent: () => boolean,
-  onPageChange: () => void,
+  onPageChange: (url: string) => void,
   dependencies: React.DependencyList = []
 ) => {
   const router = useRouter();
@@ -23,6 +25,7 @@ export const usePreventPageChange = (
   // and the Next forums are useless. Maybe do a google search periodically to
   // check whether a solution appears, or whether there's a fix to this method.
   Router.beforePopState((state: any) => {
+    log("beforePopState fired");
     let shouldHandle = true;
     POP_STATE_CALLBACKS.forEach((callback) => {
       shouldHandle = shouldHandle && callback(state);
@@ -36,38 +39,68 @@ export const usePreventPageChange = (
 
   React.useEffect(() => {
     const unloadListener = (e: BeforeUnloadEvent) => {
+      log("beforeUnload triggered");
       if (shouldCurrentlyPrevent.current) {
         e.preventDefault();
+        log("default prevented");
         e.returnValue = true;
+      } else {
+        log("default not prevented");
       }
     };
     const beforePopStateCallback = (state: any) => {
-      const currentPath = new URL(window.location.origin + state.as);
-      const newPath = new URL(window.location.origin + router.asPath);
+      // This seems backwards, but isn't if you look at the logs. History navigation is just batshit.
+      const newPath = new URL(window.location.origin + state.as);
+      log("newPath", newPath);
+      const currentPath = new URL(window.location.origin + router.asPath);
+      log("currentPath", currentPath);
       if (
         // This is changing to exactly the same path.
         (currentPath.pathname == newPath.pathname &&
           currentPath.search == newPath.search) ||
         !shouldCurrentlyPrevent.current
       ) {
+        log("shouldCurrentlyPrevent.current", shouldCurrentlyPrevent.current);
+        log("same path or not set to prevent page change");
         return true;
       }
-      if (confirm("Are you sure you want to cancel?")) {
-        onPageChange();
-        return true;
-      }
+      onPageChange(state.as);
       history.forward();
+      log("not changing, onPageChange called with", state.as);
       return false;
+    };
+
+    // The internet seems to agree that throwing an error in the routeChangeStart hamdler is the only way to cancel a route change in Next
+    // besides onPopState which only properly fires if you navigate the history
+    const abortRouteChange = () => {
+      router.events.emit("routeChangeError");
+      throw "Route change aborted by usePreventPageChange. Please ignore this error.";
+    };
+
+    const handleRouteChange = (nextRoute: string) => {
+      log(window.history.state);
+      if (
+        window.history.state.as === nextRoute ||
+        !shouldCurrentlyPrevent.current
+      ) {
+        log("same path or not set to prevent page change");
+        return;
+      }
+      log("routeChangeStart triggered to", nextRoute);
+      onPageChange(nextRoute);
+      abortRouteChange();
     };
 
     POP_STATE_CALLBACKS.push(beforePopStateCallback);
 
+    router.events.on("routeChangeStart", handleRouteChange);
     window.addEventListener("beforeunload", unloadListener);
     return () => {
       POP_STATE_CALLBACKS.splice(
         POP_STATE_CALLBACKS.indexOf(beforePopStateCallback, 1)
       );
+      router.events.off("routeChangeStart", handleRouteChange);
       window.removeEventListener("beforeunload", unloadListener);
     };
-  }, []);
+  }, [onPageChange, router.asPath, router.events]);
 };

--- a/components/hooks/usePreventPageChange.ts
+++ b/components/hooks/usePreventPageChange.ts
@@ -1,22 +1,33 @@
-import Router, { useRouter } from "next/router";
-
 import React from "react";
 import debug from "debug";
+import { useRouter } from "next/router";
 
 // @ts-expect-error
 const info = debug("bobafrontend:hooks:preventPageChange-info");
 const log = debug("bobafrontend:hooks:preventPageChange-log");
 // log.enabled = true;
 
-const POP_STATE_CALLBACKS = [] as ((state: any) => boolean)[];
+// const POP_STATE_CALLBACKS = [] as ((state: any) => boolean)[];
 export const usePreventPageChange = (
   shouldPrevent: () => boolean,
-  onPageChange: (url: string) => void,
-  dependencies: React.DependencyList = []
+  onPageChange: ({
+    url,
+    historyNavigation,
+    scrollPosition,
+  }: {
+    url: string;
+    historyNavigation: boolean;
+    scrollPosition?: { x: number; y: number };
+  }) => void
+  // dependencies: React.DependencyList = []
 ) => {
   const router = useRouter();
-  const shouldCurrentlyPrevent = React.useRef(shouldPrevent());
+  // This ref and the useEffect that was supposed to update it were not consistently registering the editor as open on board pages (it worked fine on thread pages, so ¯\_(ツ)_/¯).
+  // Clearly not too many boobies have accidentally hit the back button while creating a new thread because this bug currently exists in production.
+  // Everything works properly when I just use shouldPrevent() directly in the callbacks, but if there is a reason this needs to be a ref, more debugging will be required.
+  // const shouldCurrentlyPrevent = React.useRef(shouldPrevent());
 
+  // This workaround you had didn't seem to be doing any good.
   // The whole handling of beforePopState in next is a mess. My intuition is that
   // there's something wrong with all the "before pop state" handlers firing.
   // By adding all our callbacks to a single handler, and then cycling through
@@ -24,23 +35,27 @@ export const usePreventPageChange = (
   // TODO: this would require investigation that is honestly not worth it,
   // and the Next forums are useless. Maybe do a google search periodically to
   // check whether a solution appears, or whether there's a fix to this method.
-  Router.beforePopState((state: any) => {
-    log("beforePopState fired");
-    let shouldHandle = true;
-    POP_STATE_CALLBACKS.forEach((callback) => {
-      shouldHandle = shouldHandle && callback(state);
-    });
-    return shouldHandle;
-  });
+  // Router.beforePopState((state: any) => {
+  //   log("beforePopState fired");
+  //   let shouldHandle = true;
+  //   POP_STATE_CALLBACKS.forEach((callback) => {
+  //     shouldHandle = shouldHandle && callback(state);
+  //   });
+  //   return shouldHandle;
+  // });
 
-  React.useEffect(() => {
-    shouldCurrentlyPrevent.current = shouldPrevent();
-  }, [dependencies]);
+  // React.useEffect(() => {
+  //   shouldCurrentlyPrevent.current = shouldPrevent();
+  //   log("reset shouldCurrentlyPrevent.current");
+  //   log("shouldCurrentlyPrevent.current", shouldCurrentlyPrevent.current);
+  //   log("shouldPrevent", shouldPrevent());
+  // }, [dependencies, shouldPrevent]);
 
   React.useEffect(() => {
     const unloadListener = (e: BeforeUnloadEvent) => {
       log("beforeUnload triggered");
-      if (shouldCurrentlyPrevent.current) {
+      log("shouldPrevent", shouldPrevent());
+      if (shouldPrevent()) {
         e.preventDefault();
         log("default prevented");
         e.returnValue = true;
@@ -48,29 +63,36 @@ export const usePreventPageChange = (
         log("default not prevented");
       }
     };
-    const beforePopStateCallback = (state: any) => {
+    const beforePopStateCallback = (eventState: any) => {
       // This seems backwards, but isn't if you look at the logs. History navigation is just batshit.
-      const newPath = new URL(window.location.origin + state.as);
+      const newPath = new URL(window.location.origin + eventState.as);
       log("newPath", newPath);
       const currentPath = new URL(window.location.origin + router.asPath);
       log("currentPath", currentPath);
+      log("shouldPrevent", shouldPrevent());
       if (
         // This is changing to exactly the same path.
         (currentPath.pathname == newPath.pathname &&
           currentPath.search == newPath.search) ||
-        !shouldCurrentlyPrevent.current
+        !shouldPrevent()
       ) {
-        log("shouldCurrentlyPrevent.current", shouldCurrentlyPrevent.current);
         log("same path or not set to prevent page change");
         return true;
       }
-      onPageChange(state.as);
-      history.forward();
-      log("not changing, onPageChange called with", state.as);
+      log("history state", window.history.state);
+      onPageChange({
+        url: eventState.as,
+        historyNavigation: true,
+        scrollPosition: window.history.state.cachedScrollPosition ?? {
+          x: 0,
+          y: 0,
+        },
+      });
+      log("not changing, onPageChange called with", eventState.as);
       return false;
     };
 
-    // The internet seems to agree that throwing an error in the routeChangeStart hamdler is the only way to cancel a route change in Next
+    // The internet seems to agree that throwing an error in the routeChangeStart handler is the only way to cancel a route change in Next
     // besides onPopState which only properly fires if you navigate the history
     const abortRouteChange = () => {
       router.events.emit("routeChangeError");
@@ -79,28 +101,26 @@ export const usePreventPageChange = (
 
     const handleRouteChange = (nextRoute: string) => {
       log(window.history.state);
-      if (
-        window.history.state.as === nextRoute ||
-        !shouldCurrentlyPrevent.current
-      ) {
+      log("shouldPrevent", shouldPrevent());
+      if (window.history.state.as === nextRoute || !shouldPrevent()) {
         log("same path or not set to prevent page change");
         return;
       }
       log("routeChangeStart triggered to", nextRoute);
-      onPageChange(nextRoute);
+      onPageChange({ url: nextRoute, historyNavigation: false });
       abortRouteChange();
     };
 
-    POP_STATE_CALLBACKS.push(beforePopStateCallback);
-
+    // POP_STATE_CALLBACKS.push(beforePopStateCallback);
+    router.beforePopState(beforePopStateCallback);
     router.events.on("routeChangeStart", handleRouteChange);
     window.addEventListener("beforeunload", unloadListener);
     return () => {
-      POP_STATE_CALLBACKS.splice(
-        POP_STATE_CALLBACKS.indexOf(beforePopStateCallback, 1)
-      );
+      // POP_STATE_CALLBACKS.splice(
+      //   POP_STATE_CALLBACKS.indexOf(beforePopStateCallback, 1)
+      // );
       router.events.off("routeChangeStart", handleRouteChange);
       window.removeEventListener("beforeunload", unloadListener);
     };
-  }, [onPageChange, router.asPath, router.events]);
+  }, [onPageChange, router.asPath, router, shouldPrevent]);
 };

--- a/components/hooks/useStemOptions.ts
+++ b/components/hooks/useStemOptions.ts
@@ -5,7 +5,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 import React from "react";
-import { useAuth } from "components/Auth";
+import { RealmPermissions } from "types/Types";
+import { useEditorsState } from "components/editors/EditorsContext";
+import { useRealmPermissions } from "contexts/RealmContext";
 
 export const useStemOptions = ({
   onCollapse,
@@ -18,7 +20,8 @@ export const useStemOptions = ({
   onScrollTo: (levelId: string) => void;
   onReply: (levelId: string) => void;
 }) => {
-  const { isLoggedIn } = useAuth();
+  const realmPermissions = useRealmPermissions();
+  const editorState = useEditorsState();
 
   return React.useCallback(
     (levelId) => {
@@ -43,7 +46,10 @@ export const useStemOptions = ({
         },
       ];
 
-      if (isLoggedIn) {
+      if (
+        realmPermissions.includes(RealmPermissions.POST_ON_REALM) &&
+        !editorState.isOpen
+      ) {
         options.push({
           name: "reply up",
           icon: faPlusSquare,
@@ -56,6 +62,6 @@ export const useStemOptions = ({
       }
       return options;
     },
-    [isLoggedIn, onCollapse, onReply, onScrollTo]
+    [editorState.isOpen, onCollapse, onReply, onScrollTo, realmPermissions]
   );
 };

--- a/components/thread/CommentsThread.tsx
+++ b/components/thread/CommentsThread.tsx
@@ -175,6 +175,7 @@ const ThreadComment: React.FC<{
       <style jsx>{`
         .current-reply-outline {
           outline: 3px solid ${boardColor};
+          background-color: ${boardColor};
           border-radius: 15px;
         }
         .current-reply-header {

--- a/components/thread/ThreadPost.tsx
+++ b/components/thread/ThreadPost.tsx
@@ -361,6 +361,7 @@ const ThreadPost: React.FC<ThreadPostProps> = ({
         }
         .post.current-reply {
           outline: 5px solid ${boardColor};
+          background-color: ${boardColor};
           border-radius: 15px;
         }
         .current-reply-header {

--- a/pages/[boardId]/thread/[...threadId].tsx
+++ b/pages/[boardId]/thread/[...threadId].tsx
@@ -41,6 +41,7 @@ import { useAuth } from "components/Auth";
 import { useBeamToNew } from "components/hooks/useBeamToNew";
 import { useCachedLinks } from "components/hooks/useCachedLinks";
 import { useDisplayManager } from "components/hooks/useDisplayMananger";
+import { useEditorsState } from "components/editors/EditorsContext";
 import { useInvalidateNotifications } from "queries/notifications";
 import { useOnPageExit } from "components/hooks/useOnPageExit";
 import { useRefetchBoardActivity } from "queries/board-feed";
@@ -140,6 +141,7 @@ function ThreadPage() {
   const { postId, slug, threadId } = usePageDetails<ThreadPageDetails>();
   const boardId = useCurrentRealmBoardId({ boardSlug: slug });
   const realmPermissions = useRealmPermissions();
+  const editorState = useEditorsState();
   const { isPending: isAuthPending } = useAuth();
   const { getLinkToBoard } = useCachedLinks();
   const currentBoardData = useBoardSummary({ boardId });
@@ -268,7 +270,7 @@ function ThreadPage() {
               onNext={onNewAnswersButtonClick}
               loading={loading}
             />
-          ) : canTopLevelPost ? (
+          ) : canTopLevelPost && !editorState.isOpen ? (
             <PostingActionButton
               accentColor={currentBoardData?.accentColor || "#f96680"}
               onNewPost={() =>


### PR DESCRIPTION
Temporary solution for minimizing the editors.

There are still some cases where `usePreventPageChange` doesn't play nicely with scroll restoration, particularly when you hit the forward button with the editor open and confirm the forward navigation you end up at the top of the page regardless of whether we have a `cachedScrollPosition` for that page. But it works for the more common cases (back button), so I don't think it's worth trying to chase down these last few bugs right now.