### PR TITLE
Make Latest work in default timeline view

### DIFF
--- a/contexts/ThreadViewContext.tsx
+++ b/contexts/ThreadViewContext.tsx
@@ -1,4 +1,6 @@
 import {
+  DefaultGalleryViewQueryParamsType,
+  DefaultTimelineViewQueryParamsType,
   GALLERY_VIEW_SUB_MODE,
   GalleryViewMode,
   GalleryViewQueryParamsType,
@@ -57,7 +59,9 @@ const getQueryParamsViewMode = (query: ViewQueryParamsType) => {
 
 // Returns the TIMELINE_VIEW_SUB_MODE set in the page params.
 const getQueryParamsTimelineViewMode = (
-  timelineQuery: TimelineViewQueryParamsType
+  timelineQuery:
+    | TimelineViewQueryParamsType
+    | DefaultTimelineViewQueryParamsType
 ): ThreadViewMode["timelineViewMode"] => {
   if (timelineQuery.new) {
     return TIMELINE_VIEW_SUB_MODE.NEW;
@@ -71,7 +75,7 @@ const getQueryParamsTimelineViewMode = (
 
 // Returns the GALLERY_VIEW_SUB_MODE set in the page params.
 const getQueryParamsGalleryViewMode = (
-  galleryQuery: GalleryViewQueryParamsType
+  galleryQuery: GalleryViewQueryParamsType | DefaultGalleryViewQueryParamsType
 ): Partial<ThreadViewMode["galleryViewMode"]> => {
   if (!galleryQuery.all && !galleryQuery.new) {
     return {
@@ -173,8 +177,7 @@ const getNextView = ({
         threadViewMode: THREAD_VIEW_MODE.MASONRY,
         galleryViewMode: {
           mode:
-            // I'm not sure what this comment was supposed to mean/if that's correct
-            // We only go to "new" mode if explicitly requested or we're already in it
+            // We only go to "new" mode if explicitly requested or we're already in it, or no mode is specified and there are new updates
             currentMode
               ? currentMode
               : hasUpdates || ("new" in queryParams && queryParams.new)
@@ -194,7 +197,7 @@ const getNextView = ({
         threadViewMode: THREAD_VIEW_MODE.TIMELINE,
         galleryViewMode: null,
         timelineViewMode:
-          // We only go to "new" mode if explicitly requested or we're already in it
+          // We only go to "new" mode if explicitly requested or we're already in it, or no mode is specified and there are new updates
           currentViewMode
             ? currentViewMode
             : hasUpdates || ("new" in queryParams && queryParams.new)

--- a/types/ThreadQueryParams.ts
+++ b/types/ThreadQueryParams.ts
@@ -1,5 +1,4 @@
-import { ArrayParam, DecodedValueMap } from "use-query-params";
-
+import { DecodedValueMap } from "use-query-params";
 import { ExistanceParam } from "../components/QueryParamNextProvider";
 import { ThreadType } from "./Types";
 
@@ -102,10 +101,23 @@ export interface ThreadViewQueryParamsType {
   timeline: false;
 }
 
+export interface DefaultBaseViewQueryParamsType {
+  thread: false;
+  gallery: false;
+  timeline: false;
+}
+
 export interface GalleryViewQueryParamsType
   extends GalleryViewSpecialParamsType {
   thread: false;
   gallery: true;
+  timeline: false;
+}
+
+export interface DefaultGalleryViewQueryParamsType
+  extends GalleryViewSpecialParamsType {
+  thread: false;
+  gallery: false;
   timeline: false;
 }
 
@@ -116,21 +128,74 @@ export interface TimelineViewQueryParamsType
   timeline: true;
 }
 
+export interface DefaultTimelineViewQueryParamsType
+  extends TimelineViewSpecialParamsType {
+  thread: false;
+  gallery: false;
+  timeline: false;
+}
+
 export type ViewQueryParamsType =
   | ThreadViewQueryParamsType
   | GalleryViewQueryParamsType
   | TimelineViewQueryParamsType;
 
+export type DefaultViewQueryParamsType =
+  | DefaultGalleryViewQueryParamsType
+  | DefaultTimelineViewQueryParamsType;
+
+const includesGalleryViewSpecialParam = (
+  queryParams: DefaultViewQueryParamsType
+) => {
+  return (
+    queryParams.all == true ||
+    queryParams.new == true ||
+    ("showCover" in queryParams && queryParams.showCover == true)
+  );
+};
+
+const includesTimelineViewSpecialParam = (
+  queryParams: DefaultViewQueryParamsType
+) => {
+  return (
+    queryParams.all == true ||
+    queryParams.new == true ||
+    ("latest" in queryParams && queryParams.latest == true)
+  );
+};
+
+const isDefaultViewQueryParams = (
+  queryParams: ViewQueryParamsType | DefaultViewQueryParamsType
+): queryParams is DefaultViewQueryParamsType => {
+  return (
+    queryParams.gallery == false &&
+    queryParams.thread == false &&
+    queryParams.timeline == false
+  );
+};
+
 export const isGalleryViewQueryParams = (
-  queryParams: ViewQueryParamsType
-): queryParams is GalleryViewQueryParamsType => {
-  return queryParams.gallery == true;
+  queryParams: ViewQueryParamsType | DefaultViewQueryParamsType
+): queryParams is
+  | GalleryViewQueryParamsType
+  | DefaultGalleryViewQueryParamsType => {
+  return (
+    queryParams.gallery == true ||
+    (isDefaultViewQueryParams(queryParams) &&
+      includesGalleryViewSpecialParam(queryParams))
+  );
 };
 
 export const isTimelineViewQueryParams = (
-  queryParams: ViewQueryParamsType
-): queryParams is TimelineViewQueryParamsType => {
-  return queryParams.timeline == true;
+  queryParams: ViewQueryParamsType | DefaultViewQueryParamsType
+): queryParams is
+  | TimelineViewQueryParamsType
+  | DefaultTimelineViewQueryParamsType => {
+  return (
+    queryParams.timeline == true ||
+    (isDefaultViewQueryParams(queryParams) &&
+      includesTimelineViewSpecialParam(queryParams))
+  );
 };
 
 export const isThreadViewQueryParams = (


### PR DESCRIPTION
Adds typing for default view query params to allow getting the requested sub mode when in the default view mode of the thread.