### PR TITLE
Add menu options to copy comment/comment chain data

### DIFF
--- a/src/components/options/comment/useDebugOptions.ts
+++ b/src/components/options/comment/useDebugOptions.ts
@@ -1,0 +1,41 @@
+import React from "react";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { faBug } from "@fortawesome/free-solid-svg-icons";
+
+enum DebugOptions {
+  COPY_CONTENT_DATA = "COPY_CONTENT_DATA",
+  COPY_CHAIN_CONTENT_DATA = "COPY_CHAIN_CONTENT_DATA",
+}
+export const useDebugOptions = ({ comment: CommentType, commentChain }) => {
+  React.useMemo(() => {
+    return {
+      icon: faBug,
+      name: "Debug",
+      options: [
+        {
+          icon: faCopy,
+          name: "Copy content data",
+          link: {
+            onClick: () => {
+              copyText(comment.content);
+              toast.success("Data copied!");
+            },
+          },
+        },
+        {
+          icon: faCopy,
+          name: "Copy comment chain content data",
+          link: {
+            onClick: () => {
+              const chainContent = JSON.stringify(
+                commentChain.map((comment) => JSON.parse(comment.content)),
+              );
+              copyText(chainContent);
+              toast.success("Data copied!");
+            },
+          },
+        },
+      ],
+    };
+  }, [comment, commentChain])
+};

--- a/src/components/options/comment/useDebugOptions.ts
+++ b/src/components/options/comment/useDebugOptions.ts
@@ -1,12 +1,17 @@
+import { CommentType } from "types/Types";
 import React from "react";
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { copyText } from "utils/text-utils";
 import { faBug } from "@fortawesome/free-solid-svg-icons";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { toast } from "@bobaboard/ui-components";
 
 enum DebugOptions {
   COPY_CONTENT_DATA = "COPY_CONTENT_DATA",
   COPY_CHAIN_CONTENT_DATA = "COPY_CHAIN_CONTENT_DATA",
 }
-export const useDebugOptions = ({ comment: CommentType, commentChain }) => {
+
+export const useDebugOptions = (props: { comments: CommentType[] }) => {
+  const { comments } = props;
   React.useMemo(() => {
     return {
       icon: faBug,
@@ -17,7 +22,7 @@ export const useDebugOptions = ({ comment: CommentType, commentChain }) => {
           name: "Copy content data",
           link: {
             onClick: () => {
-              copyText(comment.content);
+              copyText(comments[0].content);
               toast.success("Data copied!");
             },
           },
@@ -28,7 +33,7 @@ export const useDebugOptions = ({ comment: CommentType, commentChain }) => {
           link: {
             onClick: () => {
               const chainContent = JSON.stringify(
-                commentChain.map((comment) => JSON.parse(comment.content)),
+                comments.map((comment) => JSON.parse(comment.content))
               );
               copyText(chainContent);
               toast.success("Data copied!");
@@ -37,5 +42,5 @@ export const useDebugOptions = ({ comment: CommentType, commentChain }) => {
         },
       ],
     };
-  }, [comment, commentChain])
+  }, [comments]);
 };

--- a/src/components/options/comment/useDebugOptions.ts
+++ b/src/components/options/comment/useDebugOptions.ts
@@ -5,11 +5,6 @@ import { faBug } from "@fortawesome/free-solid-svg-icons";
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { toast } from "@bobaboard/ui-components";
 
-enum DebugOptions {
-  COPY_CONTENT_DATA = "COPY_CONTENT_DATA",
-  COPY_TOP_COMMENT_ID = "COPY_TOP_COMMENT_ID",
-}
-
 export const useDebugOptions = (props: { comments: CommentType[] }) => {
   const { comments } = props;
   return React.useMemo(() => {

--- a/src/components/options/comment/useDebugOptions.ts
+++ b/src/components/options/comment/useDebugOptions.ts
@@ -12,7 +12,7 @@ enum DebugOptions {
 
 export const useDebugOptions = (props: { comments: CommentType[] }) => {
   const { comments } = props;
-  React.useMemo(() => {
+  return React.useMemo(() => {
     return {
       icon: faBug,
       name: "Debug",

--- a/src/components/options/comment/useDebugOptions.ts
+++ b/src/components/options/comment/useDebugOptions.ts
@@ -7,7 +7,7 @@ import { toast } from "@bobaboard/ui-components";
 
 enum DebugOptions {
   COPY_CONTENT_DATA = "COPY_CONTENT_DATA",
-  COPY_CHAIN_CONTENT_DATA = "COPY_CHAIN_CONTENT_DATA",
+  COPY_TOP_COMMENT_ID = "COPY_TOP_COMMENT_ID",
 }
 
 export const useDebugOptions = (props: { comments: CommentType[] }) => {
@@ -22,20 +22,24 @@ export const useDebugOptions = (props: { comments: CommentType[] }) => {
           name: "Copy content data",
           link: {
             onClick: () => {
-              copyText(comments[0].content);
+              const content =
+                comments.length > 1
+                  ? JSON.stringify(
+                      comments.map((comment) => JSON.parse(comment.content))
+                    )
+                  : comments[0].content;
+              copyText(content);
               toast.success("Data copied!");
             },
           },
         },
         {
           icon: faCopy,
-          name: "Copy comment chain content data",
+          name:
+            comments.length > 1 ? "Copy comment chain id" : "Copy comment id",
           link: {
             onClick: () => {
-              const chainContent = JSON.stringify(
-                comments.map((comment) => JSON.parse(comment.content))
-              );
-              copyText(chainContent);
+              copyText(comments[0].commentId);
               toast.success("Data copied!");
             },
           },

--- a/src/components/options/useCommentOptions.ts
+++ b/src/components/options/useCommentOptions.ts
@@ -1,7 +1,6 @@
 import { CommentType, RealmPermissions } from "types/Types";
 import { ThreadPageDetails, usePageDetails } from "utils/router-utils";
 import { faArrowRight, faLink } from "@fortawesome/free-solid-svg-icons";
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import {
   useCurrentRealmBoardId,
   useRealmPermissions,
@@ -11,15 +10,16 @@ import { DropdownProps } from "@bobaboard/ui-components/dist/common/DropdownList
 import React from "react";
 import { copyText } from "utils/text-utils";
 import { faComment } from "@fortawesome/free-regular-svg-icons";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { getCommentsChain } from "components/thread/CommentsThread";
 import { isNotNull } from "utils/typescript-utils";
 import { toast } from "@bobaboard/ui-components";
 import { useBoardMetadata } from "lib/api/hooks/board";
 import { useCachedLinks } from "components/hooks/useCachedLinks";
+import { useDebugOptions } from "./comment/useDebugOptions";
 import { useEditorsState } from "components/core/editors/EditorsContext";
 import { useThreadContext } from "components/thread/ThreadContext";
 import { useThreadEditors } from "components/core/editors/withEditors";
-import { useDebugOptions } from "./comment/useDebugOptions";
 
 export enum CommentOptions {
   GO_TO_COMMENT = "GO_TO_COMMENT",
@@ -111,7 +111,7 @@ export const useCommentOptions = ({
               };
             }
             case CommentOptions.DEBUG: {
-              return useDebugOptions({ comment, commentChain });
+              return useDebugOptions({ comments: commentChain });
             }
           }
         })
@@ -125,6 +125,7 @@ export const useCommentOptions = ({
       linkToComment,
       onNewComment,
       parentPostId,
+      commentChain,
     ]
   );
 };

--- a/src/components/options/useCommentOptions.ts
+++ b/src/components/options/useCommentOptions.ts
@@ -19,13 +19,13 @@ import { useCachedLinks } from "components/hooks/useCachedLinks";
 import { useEditorsState } from "components/core/editors/EditorsContext";
 import { useThreadContext } from "components/thread/ThreadContext";
 import { useThreadEditors } from "components/core/editors/withEditors";
+import { useDebugOptions } from "./comment/useDebugOptions";
 
 export enum CommentOptions {
   GO_TO_COMMENT = "GO_TO_COMMENT",
-  COPY_CONTENT_DATA = "COPY_CONTENT_DATA",
-  COPY_CHAIN_CONTENT_DATA = "COPY_CHAIN_CONTENT_DATA",
   COPY_COMMENT_LINK = "COPY_COMMENT_LINK",
   REPLY_TO_COMMENT = "REPLY_TO_COMMENT",
+  DEBUG = "DEBUG",
 }
 
 /**
@@ -73,33 +73,6 @@ export const useCommentOptions = ({
       options
         .map((option) => {
           switch (option) {
-            case CommentOptions.COPY_CONTENT_DATA: {
-              return {
-                icon: faCopy,
-                name: "Copy content data",
-                link: {
-                  onClick: () => {
-                    copyText(comment.content);
-                    toast.success("Data copied!");
-                  },
-                },
-              };
-            }
-            case CommentOptions.COPY_CHAIN_CONTENT_DATA: {
-              return {
-                icon: faCopy,
-                name: "Copy comment chain content data",
-                link: {
-                  onClick: () => {
-                    const chainContent = JSON.stringify(
-                      commentChain.map((comment) => JSON.parse(comment.content)),
-                    );
-                    copyText(chainContent);
-                    toast.success("Data copied!");
-                  },
-                },
-              };
-            }
             case CommentOptions.COPY_COMMENT_LINK: {
               return {
                 icon: faLink,
@@ -136,6 +109,9 @@ export const useCommentOptions = ({
                   label: "Add a new comment",
                 },
               };
+            }
+            case CommentOptions.DEBUG: {
+              return useDebugOptions({ comment, commentChain });
             }
           }
         })

--- a/src/components/options/useCommentOptions.ts
+++ b/src/components/options/useCommentOptions.ts
@@ -10,7 +10,6 @@ import { DropdownProps } from "@bobaboard/ui-components/dist/common/DropdownList
 import React from "react";
 import { copyText } from "utils/text-utils";
 import { faComment } from "@fortawesome/free-regular-svg-icons";
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { getCommentsChain } from "components/thread/CommentsThread";
 import { isNotNull } from "utils/typescript-utils";
 import { toast } from "@bobaboard/ui-components";

--- a/src/components/options/useCommentOptions.ts
+++ b/src/components/options/useCommentOptions.ts
@@ -62,6 +62,7 @@ export const useCommentOptions = ({
 
   const commentChain = getCommentsChain(comment, parentChainMap);
   const lastCommentChainId = commentChain[commentChain.length - 1].commentId;
+  const debugOptions = useDebugOptions({ comments: commentChain });
 
   // TODO: we should also return null if the editor is open
   const canReplyToComment =
@@ -78,6 +79,7 @@ export const useCommentOptions = ({
                 icon: faLink,
                 name: "Copy link to comment",
                 link: {
+                  // @ts-expect-error TODO: figure this out
                   onClick: () => {
                     copyText(
                       new URL(
@@ -111,7 +113,7 @@ export const useCommentOptions = ({
               };
             }
             case CommentOptions.DEBUG: {
-              return useDebugOptions({ comments: commentChain });
+              return debugOptions;
             }
           }
         })
@@ -125,7 +127,7 @@ export const useCommentOptions = ({
       linkToComment,
       onNewComment,
       parentPostId,
-      commentChain,
+      debugOptions,
     ]
   );
 };

--- a/src/components/options/useCommentOptions.ts
+++ b/src/components/options/useCommentOptions.ts
@@ -1,6 +1,7 @@
 import { CommentType, RealmPermissions } from "types/Types";
 import { ThreadPageDetails, usePageDetails } from "utils/router-utils";
 import { faArrowRight, faLink } from "@fortawesome/free-solid-svg-icons";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import {
   useCurrentRealmBoardId,
   useRealmPermissions,
@@ -21,6 +22,8 @@ import { useThreadEditors } from "components/core/editors/withEditors";
 
 export enum CommentOptions {
   GO_TO_COMMENT = "GO_TO_COMMENT",
+  COPY_CONTENT_DATA = "COPY_CONTENT_DATA",
+  COPY_CHAIN_CONTENT_DATA = "COPY_CHAIN_CONTENT_DATA",
   COPY_COMMENT_LINK = "COPY_COMMENT_LINK",
   REPLY_TO_COMMENT = "REPLY_TO_COMMENT",
 }
@@ -70,6 +73,33 @@ export const useCommentOptions = ({
       options
         .map((option) => {
           switch (option) {
+            case CommentOptions.COPY_CONTENT_DATA: {
+              return {
+                icon: faCopy,
+                name: "Copy content data",
+                link: {
+                  onClick: () => {
+                    copyText(comment.content);
+                    toast.success("Data copied!");
+                  },
+                },
+              };
+            }
+            case CommentOptions.COPY_CHAIN_CONTENT_DATA: {
+              return {
+                icon: faCopy,
+                name: "Copy comment chain content data",
+                link: {
+                  onClick: () => {
+                    const chainContent = JSON.stringify(
+                      commentChain.map((comment) => JSON.parse(comment.content)),
+                    );
+                    copyText(chainContent);
+                    toast.success("Data copied!");
+                  },
+                },
+              };
+            }
             case CommentOptions.COPY_COMMENT_LINK: {
               return {
                 icon: faLink,

--- a/src/components/options/useCommentOptions.ts
+++ b/src/components/options/useCommentOptions.ts
@@ -78,7 +78,6 @@ export const useCommentOptions = ({
                 icon: faLink,
                 name: "Copy link to comment",
                 link: {
-                  // @ts-expect-error TODO: figure this out
                   onClick: () => {
                     copyText(
                       new URL(

--- a/src/components/thread/CommentsThread.tsx
+++ b/src/components/thread/CommentsThread.tsx
@@ -37,8 +37,6 @@ import { useThreadEditors } from "components/core/editors/withEditors";
 
 const COMMENT_OPTIONS = [
   CommentOptions.GO_TO_COMMENT,
-  CommentOptions.COPY_CONTENT_DATA,
-  CommentOptions.COPY_CHAIN_CONTENT_DATA,
   CommentOptions.COPY_COMMENT_LINK,
   CommentOptions.REPLY_TO_COMMENT,
   CommentOptions.DEBUG,

--- a/src/components/thread/CommentsThread.tsx
+++ b/src/components/thread/CommentsThread.tsx
@@ -37,6 +37,8 @@ import { useThreadEditors } from "components/core/editors/withEditors";
 
 const COMMENT_OPTIONS = [
   CommentOptions.GO_TO_COMMENT,
+  CommentOptions.COPY_CONTENT_DATA,
+  CommentOptions.COPY_CHAIN_CONTENT_DATA,
   CommentOptions.COPY_COMMENT_LINK,
   CommentOptions.REPLY_TO_COMMENT,
 ];

--- a/src/components/thread/CommentsThread.tsx
+++ b/src/components/thread/CommentsThread.tsx
@@ -41,6 +41,7 @@ const COMMENT_OPTIONS = [
   CommentOptions.COPY_CHAIN_CONTENT_DATA,
   CommentOptions.COPY_COMMENT_LINK,
   CommentOptions.REPLY_TO_COMMENT,
+  CommentOptions.DEBUG,
 ];
 
 // TODO: consider doing this directly as part of ThreadCommentInfoType.


### PR DESCRIPTION
These should actually go in a Debug sub-menu.

I'm not sure if the format for comment chains is right.